### PR TITLE
FIX: comma-separated item parsing faulty

### DIFF
--- a/cache_status.sh
+++ b/cache_status.sh
@@ -4,16 +4,16 @@ ARCH_HOST=${ARCH_HOST=localhost:17665}
 APPLIANCES=${APPLIANCES=pscaa01 pscaa02}
 
 echo "Caching information for testing from ${ARCH_HOST}..."
-# curl ${ARCH_HOST}/mgmt/bpl/getApplianceMetrics  > archstats/tests/json/getApplianceMetrics.json
-# curl ${ARCH_HOST}/mgmt/bpl/getStorageMetrics  > archstats/tests/json/getStorageMetrics.json
-# curl ${ARCH_HOST}/mgmt/bpl/getInstanceMetrics  > archstats/tests/json/getInstanceMetrics.json
+curl ${ARCH_HOST}/mgmt/bpl/getApplianceMetrics  > archstats/tests/json/getApplianceMetrics.json
+curl ${ARCH_HOST}/mgmt/bpl/getStorageMetrics  > archstats/tests/json/getStorageMetrics.json
+curl ${ARCH_HOST}/mgmt/bpl/getInstanceMetrics  > archstats/tests/json/getInstanceMetrics.json
 curl ${ARCH_HOST}/mgmt/bpl/getProcessMetrics  > archstats/tests/json/getProcessMetrics.json
 
  for appliance in ${APPLIANCES}; do
     echo "Appliance ${appliance}"
-#     curl "${ARCH_HOST}/mgmt/bpl/getApplianceMetricsForAppliance?appliance=${appliance}"  > archstats/tests/json/getApplianceMetricsForAppliance-${appliance}.json
-#     curl "${ARCH_HOST}/mgmt/bpl/getProcessMetricsDataForAppliance?appliance=${appliance}"  > archstats/tests/json/getProcessMetricsDataForAppliance-${appliance}.json
-    # curl "${ARCH_HOST}/mgmt/bpl/getStorageMetricsForAppliance?appliance=${appliance}"  > archstats/tests/json/getStorageMetricsForAppliance-${appliance}.json
+    curl "${ARCH_HOST}/mgmt/bpl/getApplianceMetricsForAppliance?appliance=${appliance}"  > archstats/tests/json/getApplianceMetricsForAppliance-${appliance}.json
+    curl "${ARCH_HOST}/mgmt/bpl/getProcessMetricsDataForAppliance?appliance=${appliance}"  > archstats/tests/json/getProcessMetricsDataForAppliance-${appliance}.json
+    curl "${ARCH_HOST}/mgmt/bpl/getStorageMetricsForAppliance?appliance=${appliance}"  > archstats/tests/json/getStorageMetricsForAppliance-${appliance}.json
     # DO NOT include these -- too large:
     # curl "${ARCH_HOST}/mgmt/bpl/getCreationReportForAppliance?appliance=${appliance}"  > archstats/tests/json/getCreationReportForAppliance-${appliance}.json
  done


### PR DESCRIPTION
Saw:

```
elasticsearch.exceptions.RequestError: RequestError(400, 'mapper_parsing_exception', "failed to parse field [data_rate_in_bytes_per_sec] │27179 root      20   0  181.4m   5.8m   4.5m S   0.0  0.2   0:00.02 sshd
of type [float] in document with id '582c0a1d-a706-4ba2-be4a-03806a544a6c'. Preview of field's value: '101,003'")                        
```

That is `101,003` was failing `literal_eval` due to the `003` portion, and the string was getting through to the elastic document. Sometimes regexes really are the best option.