### PR TITLE
REF: use utc time instead

### DIFF
--- a/archstats/db_backed.py
+++ b/archstats/db_backed.py
@@ -103,8 +103,7 @@ def get_latest_timestamp(instances: Tuple[PvpropertyData, ...]) -> datetime.date
         channeldata.timestamp for channeldata in instances
     )
 
-    dt = datetime.datetime.fromtimestamp(latest_posix_stamp)
-    return dt.astimezone(datetime.timezone.utc)
+    return datetime.datetime.fromtimestamp(latest_posix_stamp).astimezone()
 
 
 async def restore_from_document(group: PVGroup, doc: dict,
@@ -167,7 +166,9 @@ class DatabaseHandler(DatabaseHandlerInterface):
         if not document:
             return None
 
-        document[self.TIMESTAMP_KEY] = self.get_timestamp_from_instances(instances)
+        # Keep the document timestamp in UTC time:
+        dt = self.get_timestamp_from_instances(instances)
+        document[self.TIMESTAMP_KEY] = dt.astimezone(datetime.timezone.utc)
         return document
 
     async def restore_from_document(self, doc: dict):
@@ -255,8 +256,8 @@ class ElasticHandler(DatabaseHandler):
 
     @property
     def date_suffix(self) -> str:
-        """Date suffix for use with the index name."""
-        return datetime.datetime.now().strftime(self.date_suffix_format)
+        """UTC time date suffix for use with the index name."""
+        return datetime.datetime.utcnow().strftime(self.date_suffix_format)
 
     async def startup(self, group: PVGroup, async_lib: AsyncLibraryLayer):
         """Startup hook."""

--- a/archstats/db_backed.py
+++ b/archstats/db_backed.py
@@ -103,7 +103,8 @@ def get_latest_timestamp(instances: Tuple[PvpropertyData, ...]) -> datetime.date
         channeldata.timestamp for channeldata in instances
     )
 
-    return datetime.datetime.fromtimestamp(latest_posix_stamp).astimezone()
+    dt = datetime.datetime.fromtimestamp(latest_posix_stamp)
+    return dt.astimezone(datetime.timezone.utc)
 
 
 async def restore_from_document(group: PVGroup, doc: dict,


### PR DESCRIPTION
This may sidestep some timezone-related issues with elasticsearch + grafana.

Not seeing any skipped data points after having restarted the IOC, so I'm reasonably confident this works. Whether or not it will ~close~ #12 remains to be seen (a few hours from now...)

Closes #12 