### PR TITLE
BLD: bump caproto min version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp[speedups]
-caproto[standard]
+caproto[standard]>=0.7.0
 elasticsearch[async]>=7.8.0
 inflection
 versioneer


### PR DESCRIPTION
v0.6.0 is the ~actual~ probable minimum, but we want v0.7.0 to build documentation.