### PR TITLE
BLD: Bump caproto version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,32 +1,30 @@
-
 {% set data = load_setup_py_data() %}
 
-
 package:
-    name    : archstats
-
-    version : {{ data.get('version') }}
-
+    name: archstats
+    version: {{ data.get('version') }}
 
 source:
     path: ..
 
 build:
-    number: 1
+    number: 2
     noarch: python
 
 requirements:
     build:
       - python >=3.6
       - setuptools
-
     run:
       - python >=3.6
+      - aiohttp
+      - caproto >=0.7.1
+      - elasticsearch >=7.8.0
+      - inflection
 
 test:
     imports:
       - archstats
-
     requires:
       - pytest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp[speedups]
-caproto[standard]>=0.7.0
+caproto[standard]>=0.7.1
 elasticsearch[async]>=7.8.0
 inflection
 versioneer


### PR DESCRIPTION
Also a first pass at fixing up the conda recipe. Pip specifiers may have some implicit requirements that the conda recipes do not - that may need investigation.